### PR TITLE
Use varnish-rs's Ctx::req_body/req_body_state for request body forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,9 +1798,8 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "varnish"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83525c8e2200dc7d0db8e485d8bccdf54ff17593c2cbebce81397aeb322e465"
+version = "0.7.1"
+source = "git+https://github.com/varnish-rs/varnish-rs.git?rev=27bab58#27bab58f4c3bfa5b52fa8bfd1a5fe1287d1ec10b"
 dependencies = [
  "glob",
  "varnish-macros",
@@ -1809,9 +1808,8 @@ dependencies = [
 
 [[package]]
 name = "varnish-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f670639c252a95fd46c150fb9e3e38ea1e92b73aa0a3ecca52f0d0e4f491ddf"
+version = "0.7.1"
+source = "git+https://github.com/varnish-rs/varnish-rs.git?rev=27bab58#27bab58f4c3bfa5b52fa8bfd1a5fe1287d1ec10b"
 dependencies = [
  "darling",
  "glob",
@@ -1828,9 +1826,8 @@ dependencies = [
 
 [[package]]
 name = "varnish-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f34ef7aa58328c4d5c32fa19185558db780a25bdf5fb2d7ba0c6b6ac4d8e774"
+version = "0.7.1"
+source = "git+https://github.com/varnish-rs/varnish-rs.git?rev=27bab58#27bab58f4c3bfa5b52fa8bfd1a5fe1287d1ec10b"
 dependencies = [
  "bindgen_helpers",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ reqwest = { version = "0.12", features = ["stream", "deflate", "gzip", "brotli",
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.17"
-varnish = { version = "0.7.0", features = ["ffi"] }
+varnish = { git = "https://github.com/varnish-rs/varnish-rs.git", rev = "27bab58", features = ["ffi"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -1,7 +1,6 @@
 pub mod reqwest_private {
     use std::boxed::Box;
     use std::io::Write;
-    use std::os::raw::{c_uint, c_void};
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{Duration, Instant, SystemTime};
@@ -10,11 +9,25 @@ pub mod reqwest_private {
     use bytes::Bytes;
     use reqwest::{Client, Url};
     use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender};
-    use varnish::ffi::{BS_CACHED, BS_ERROR, BS_NONE};
-    use varnish::vcl::{Backend, StrOrBytes, VclBackend, VclResponse};
+    use varnish::vcl::{Backend, BodyState, StrOrBytes, VclBackend, VclResponse};
     use varnish::vcl::{
         Buffer, Ctx, Event, LogTag, Probe, Request as ProbeRequest, VclError, VclResult, log,
     };
+
+    struct BodySender(UnboundedSender<Result<Bytes, String>>);
+
+    impl Write for BodySender {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .send(Ok(Bytes::copy_from_slice(buf)))
+                .map_err(|_| std::io::Error::other("receiver dropped"))?;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     pub struct ProbeState {
         spec: Probe,
@@ -50,30 +63,6 @@ pub mod reqwest_private {
     #[allow(clippy::extra_unused_lifetimes)]
     impl<'a> VclBackend<BackendResp> for VCLBackend {
         fn get_response(&self, ctx: &mut Ctx<'_>) -> VclResult<Option<BackendResp>> {
-            unsafe extern "C" fn body_send_iterate(
-                priv_: *mut c_void,
-                _flush: c_uint,
-                ptr: *const c_void,
-                l: isize,
-            ) -> i32 {
-                // nothing to do
-                if ptr.is_null() || l == 0 {
-                    return 0;
-                }
-                #[expect(clippy::cast_sign_loss)]
-                let (body_chan, buf) = unsafe {
-                    let body_chan = priv_
-                        .cast::<UnboundedSender<Result<Bytes, String>>>()
-                        .as_mut()
-                        .unwrap();
-                    let buf = std::slice::from_raw_parts(ptr.cast::<u8>(), l as usize);
-                    (body_chan, buf)
-                };
-                let bytes = Bytes::copy_from_slice(buf);
-
-                body_chan.send(Ok(bytes)).is_err().into()
-            }
-
             if !self.probe(ctx).0 {
                 return Err("unhealthy".into());
             }
@@ -116,51 +105,13 @@ pub mod reqwest_private {
                     .collect(),
             };
 
-            unsafe {
-                let bo = ctx.raw.bo.as_mut().unwrap();
-                if !bo.bereq_body.is_null()
-                    || (!bo.req.is_null() && (*bo.req).req_body_status != BS_NONE.as_ptr())
-                {
-                    let (mut req_body_tx, req_body_rx) =
-                        tokio::sync::mpsc::unbounded_channel::<Result<Bytes, String>>();
-                    req.body = Some(reqwest::Body::wrap_stream(
-                        tokio_stream::wrappers::UnboundedReceiverStream::new(req_body_rx),
-                    ));
-                    // manually dropped a few lines below
-                    let p = (&raw mut req_body_tx).cast::<c_void>();
-
-                    // mimicking V1F_SendReq in varnish-cache
-                    if bo.bereq_body.is_null() {
-                        let i = varnish::ffi::VRB_Iterate(
-                            bo.wrk,
-                            bo.vsl.as_mut_ptr(),
-                            bo.req,
-                            Some(body_send_iterate),
-                            p,
-                        );
-
-                        if (*bo.req).req_body_status != BS_CACHED.as_ptr() {
-                            bo.no_retry = c"req.body not cached".as_ptr();
-                        }
-
-                        if (*bo.req).req_body_status == BS_ERROR.as_ptr() {
-                            assert!(i < 0);
-                            (*bo.req).doclose = &raw const varnish::ffi::SC_RX_BODY[0];
-                        }
-
-                        if i < 0 {
-                            return Err("req.body read error".into());
-                        }
-                    } else {
-                        varnish::ffi::ObjIterate(
-                            bo.wrk,
-                            bo.bereq_body,
-                            p,
-                            Some(body_send_iterate),
-                            0,
-                        );
-                    }
-                }
+            if ctx.req_body_state()? != BodyState::None {
+                let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<Bytes, String>>();
+                req.body = Some(reqwest::Body::wrap_stream(
+                    tokio_stream::wrappers::UnboundedReceiverStream::new(rx),
+                ));
+                ctx.req_body(&mut BodySender(tx))
+                    .map_err(|e| format!("req.body read error: {e}"))?;
             }
             let mut resp_rx = unsafe { (*self.bgt).spawn_req(req) };
 

--- a/tests/test15.vtc
+++ b/tests/test15.vtc
@@ -1,0 +1,47 @@
+varnishtest "backend() retry without a cached body must be refused"
+
+server s1 {
+	rxreq
+	expect req.body == "0123456789"
+	txresp
+} -start
+
+# VCL, no backend needed
+varnish v1 -vcl {
+	import reqwest from "${vmod}";
+
+	backend s1 none;
+
+	sub vcl_init {
+		new client = reqwest.client();
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = client.backend();
+	}
+
+	sub vcl_backend_response {
+		if (bereq.retries == 0) {
+			return (retry);
+		}
+	}
+} -start
+
+logexpect l1 -v v1 -i Error {
+	expect 0 * Error "Retry not possible, bereq.body not cached"
+} -start
+
+# no std.cache_req_body(), so the body is streamed straight from the client
+# and never cached. reqwest's backend reads it via Ctx::req_body(), which sets
+# bo.no_retry since it wasn't cached -- Varnish must refuse the forced retry
+# above and fall back to a synth error rather than re-reading the consumed
+# body against s1 a second time.
+client c1 {
+	txreq -method "POST" -hdr "host: ${s1_addr}:${s1_port}" -body "0123456789"
+	rxresp
+	expect resp.status == 503
+} -run
+
+logexpect l1 -wait
+
+server s1 -wait


### PR DESCRIPTION
## Summary
- Replace the hand-rolled FFI body-forwarding (`VRB_Iterate`/`ObjIterate` + a manual `unsafe extern "C"` callback mimicking `V1F_SendReq`) with varnish-rs's new `Ctx::req_body`/`Ctx::req_body_state`, which handles the same cache/stream dispatch and `no_retry`/`doclose`/`err_code` bookkeeping internally.
- Temporarily depend on varnish-rs `main` via git rev (`27bab58`) since this API isn't in a crates.io release yet — swap back to a version pin once one ships.
- Add `tests/test15.vtc`: forces a retry with an uncached request body and verifies Varnish refuses it (`bo.no_retry`), including a `logexpect` on the `Retry not possible, bereq.body not cached` error.

## Test plan
- [x] `cargo build` / `cargo clippy --all-targets` clean
- [x] `cargo test` — all 15 VTC tests pass, including the new `vtc_test15`