### PR TITLE
Address Copilot review comments from PR #37

### DIFF
--- a/src/implementation/reqwest_private/backend.rs
+++ b/src/implementation/reqwest_private/backend.rs
@@ -118,7 +118,9 @@ impl<'a> VclBackend<BackendResp> for VCLBackend {
             .content_length()
             .map(usize::try_from)
             .transpose()
-            .map_err(|e| <String as Into<VclError>>::into(format!("invalid content-length ({e})")))?;
+            .map_err(|e| {
+                <String as Into<VclError>>::into(format!("invalid content-length ({e})"))
+            })?;
         Ok(Some(BackendResp {
             resp,
             content_length,

--- a/src/implementation/reqwest_private/backend.rs
+++ b/src/implementation/reqwest_private/backend.rs
@@ -114,7 +114,11 @@ impl<'a> VclBackend<BackendResp> for VCLBackend {
                     .map_err(|e| <String as Into<VclError>>::into(e.to_string()))?,
             )?;
         }
-        let content_length = resp.content_length().map(|s| usize::try_from(s).unwrap());
+        let content_length = resp
+            .content_length()
+            .map(usize::try_from)
+            .transpose()
+            .map_err(|e| <String as Into<VclError>>::into(format!("invalid content-length ({e})")))?;
         Ok(Some(BackendResp {
             resp,
             content_length,

--- a/src/implementation/reqwest_private/backend.rs
+++ b/src/implementation/reqwest_private/backend.rs
@@ -116,11 +116,12 @@ impl<'a> VclBackend<BackendResp> for VCLBackend {
         }
         let content_length = resp
             .content_length()
-            .map(usize::try_from)
-            .transpose()
-            .map_err(|e| {
-                <String as Into<VclError>>::into(format!("invalid content-length ({e})"))
-            })?;
+            .map(|s| {
+                usize::try_from(s).map_err(|e| {
+                    <String as Into<VclError>>::into(format!("invalid content-length ({s}): {e}"))
+                })
+            })
+            .transpose()?;
         Ok(Some(BackendResp {
             resp,
             content_length,

--- a/src/implementation/reqwest_private/vcl_client.rs
+++ b/src/implementation/reqwest_private/vcl_client.rs
@@ -76,9 +76,9 @@ pub struct BgThread {
 impl BgThread {
     fn spawn_req(&self, req: Request) -> Receiver<Result<Response, Error>> {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
-        self.sender
-            .send((req, tx))
-            .expect("BgThread's receiver loop is gone, but it must outlive every client backed by this VCL");
+        self.sender.send((req, tx)).expect(
+            "BgThread's receiver loop is gone, but it must outlive every client backed by this VCL",
+        );
         rx
     }
 }

--- a/src/implementation/reqwest_private/vcl_client.rs
+++ b/src/implementation/reqwest_private/vcl_client.rs
@@ -76,7 +76,9 @@ pub struct BgThread {
 impl BgThread {
     fn spawn_req(&self, req: Request) -> Receiver<Result<Response, Error>> {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
-        self.sender.send((req, tx)).unwrap();
+        self.sender
+            .send((req, tx))
+            .expect("BgThread's receiver loop is gone, but it must outlive every client backed by this VCL");
         rx
     }
 }
@@ -135,7 +137,10 @@ impl client {
                 Self::wait_on(bgt, t);
             }
             VclTransaction::Sent(rx) => {
-                *t = match rx.blocking_recv().unwrap() {
+                *t = match rx
+                    .blocking_recv()
+                    .expect("BgThread dropped the response sender without replying")
+                {
                     Ok(resp) => VclTransaction::Resp(Ok(resp)),
                     Err(e) => VclTransaction::Resp(Err(format!("{e}: {}", e.root_cause()).into())),
                 };
@@ -187,7 +192,12 @@ impl client {
         name: &'a str,
     ) -> VclResult<Result<&'a Response, VclError>> {
         let t = self.get_transaction(vp_task, name)?;
-        Self::wait_on(vp_vcl.as_ref().unwrap(), t);
+        Self::wait_on(
+            vp_vcl
+                .as_ref()
+                .expect("BgThread priv should be initialized for the lifetime of the VCL"),
+            t,
+        );
         Ok(t.unwrap_resp())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,11 @@ mod reqwest {
                 vrcb = vrcb.redirect(reqwest::redirect::Policy::none());
                 brcb = brcb.redirect(reqwest::redirect::Policy::none());
             } else {
-                let n = usize::try_from(follow).unwrap();
+                let n = usize::try_from(follow).map_err(|_| {
+                    VclError::new(format!(
+                        "reqwest: couldn't initialize {vcl_name}: follow value ({follow}) is too large"
+                    ))
+                })?;
                 vrcb = vrcb.redirect(reqwest::redirect::Policy::limited(n));
                 brcb = brcb.redirect(reqwest::redirect::Policy::limited(n));
             }


### PR DESCRIPTION
## Summary

Follow-up to address the 3 Copilot review comments left on #37 after it was merged:

- **`follow` conversion** ([comment](https://github.com/varnish-rs/vmod-reqwest/pull/37#discussion_r3753888232)): `usize::try_from(follow).unwrap()` in `src/lib.rs` could panic for a `follow` value too large for `usize`. Now returns a `VclError` instead.
- **Content-Length conversion** ([comment](https://github.com/varnish-rs/vmod-reqwest/pull/37#discussion_r3753888298)): same issue in `src/implementation/reqwest_private/backend.rs` for `resp.content_length()`. Now propagates a `VclError` rather than panicking.
- **`BgThread` channel unwraps** ([comment](https://github.com/varnish-rs/vmod-reqwest/pull/37#discussion_r3753888268)): `spawn_req`'s `self.sender.send(...).unwrap()`, plus the related `blocking_recv().unwrap()` and `vp_vcl.as_ref().unwrap()` Copilot bundled with it. These channels only break if the background receiver loop dies before the VCL that owns it, which shouldn't happen — so instead of restructuring error handling around a case that can't occur in practice, these are now `.expect("...")` with a message documenting the invariant, so a violation is at least self-explanatory instead of a bare panic.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo clippy --all-features --all-targets` — clean
- [x] `cargo test --all-features` — all 17 `.vtc` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)