### PR TITLE
Release 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       matrix:
         include:
           - ver: 9.0
-          - ver: 8.0
     steps:
       - uses: actions/checkout@v4
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+## 0.1.0
+
+- Changed: backend fetch rewired onto `reqwest::blocking` (#37)
+- Fixed: probes now inherit `accept_invalid_certs`/`accept_invalid_hostnames` from their parent backend (#30)
+- Changed: dropped Varnish 8 CI/support, minimum supported Varnish version is now 9.0+
+- Added: happy-path HTTPS backend test
+
+## 0.0.17 - 2026-06-17
+
+- Changed: updated `varnish-rs` to 0.7.0 (#34)
+- Changed: increased `VARNISHTEST_DURATION` to give Varnish 8 more time to shut down (#32)
+- Changed: refreshed README and CI (#29)
+
+## 0.0.16 - 2025-09-18
+
+- Changed: upgraded dependencies (#27)
+- Chore: unified CI config across vmods (#25)
+
+## 0.0.15 - 2025-06-02
+
+- Added: test covering an unusual `Host` header (#22)
+- Changed: ported Docker setup from `varnish-rs` (#21)
+- Fixed: buffer-consumption handling
+- Chore: sorted `justfile` (#23), various fmt/clippy cleanups (#20)
+
+## 0.0.14 - 2025-03-31
+
+- Changed: upgraded to `varnish-rs` 0.4.0
+- Added: container image build (#14)
+- Chore: API tweaks and formatting
+
+## 0.0.13 - 2024-11-12
+
+- Fixed: avoid panicking on an invalid buffer
+- Changed: switched to `varnish-rs`'s macros and new defaults
+- Changed: updated Docker image for Varnish 7.5 (#11)
+- Chore: more verbose CI
+
+## 0.0.12 - 2024-03-24
+
+- Fixed: use `c_char` correctly
+- Added: `authors` metadata
+- Chore: upgraded `bindgen` to build on newer Fedora
+
+## 0.0.11 - 2024-03-19
+
+- Added: Dockerfile support for Varnish 7.4 (#8), then updated for Varnish 7.5
+- Chore: switched to the sparse Cargo index
+
+## 0.0.10 - 2023-09-23
+
+- Added: `client.copy_headers_to_req()`
+- Released for Varnish 7.4
+
+## 0.0.9 - 2023-07-09
+
+- Changed: simplified the `header()` function
+- Fixed: Docker packaging (wrong file copied)
+
+## 0.0.8 - 2023-03-19
+
+- Maintenance release
+
+## 0.0.7 - 2023-03-19
+
+- Added: support for 0-length bodies
+- Added: `sep` argument to `.header()`
+- Changed: upgraded to `varnish-rs` 0.0.14
+- Changed: simplified error handling
+- Chore: updated Dockerfile to a more recent Rust
+
+## 0.0.6 - 2022-12-19
+
+- Added: streaming support
+- Fixed: Dockerfile/CI issues
+
+## 0.0.5 - 2022-11-29
+
+- Changed: renamed `Body` to `ReqBody` (request-only)
+- Changed: cleaned up error handling, `init()` can no longer fail
+- Added: probe tests and docs
+
+## 0.0.4 - 2022-06-22
+
+- Added: initial probe support
+- Fixed: smarter URL building
+- Chore: CI updated to Varnish 7.1, examples cleanup, Discord link added
+
+## 0.0.3 - 2022-01-30
+
+- Added: initial backend implementation, unified `client` object
+- Chore: proper dependency setup, build script, license fix
+
+## 0.0.2 - 2021-12-19
+
+- Early bring-up
+
+## 0.0.1 - 2021-12-05
+
+- Initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed: probes now inherit `accept_invalid_certs`/`accept_invalid_hostnames` from their parent backend (#30)
 - Changed: dropped Varnish 8 CI/support, minimum supported Varnish version is now 9.0+
 - Added: happy-path HTTPS backend test
+- Fixed: several panics on integer-conversion overflow (`follow`, response `Content-Length`) now return a `VclError` instead (#38)
 
 ## 0.0.17 - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0
+## 0.1.0 - 2026-08-10
 
 - Changed: backend fetch rewired onto `reqwest::blocking` (#37)
 - Fixed: probes now inherit `accept_invalid_certs`/`accept_invalid_hostnames` from their parent backend (#30)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "vmod_reqwest"
-version = "0.0.18"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmod_reqwest"
-version = "0.0.18"
+version = "0.1.0"
 edition = "2024"
 license = "BSD-3-Clause"
 authors = ["Guillaume Quintard <guillaume.quintard@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Don't hesitate to open github issues if something is unclear or impractical. You
 
 | vmod-reqwest | varnish |
 | :----------- | :-----: |
+| 0.1.0        | 9.0+ |
 | 0.0.17        | 9.0+ |
 | 0.0.16        | 8.0+ |
 | 0.0.15        | 7.7  |

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ targets := '--all-targets'  # For all targets (lib, bin, tests, examples, benche
 default_varnish_ver := '9.0'
 
 # Make sure to update CI with the changes.
-supported_varnish_vers := '8.0 9.0'
+supported_varnish_vers := '9.0'
 
 # if running in CI, treat warnings as errors by setting RUSTFLAGS and RUSTDOCFLAGS to '-D warnings' unless they are already set
 # Use `CI=true just ci-test` to run the same tests as in GitHub CI.

--- a/tests/test17.vtc
+++ b/tests/test17.vtc
@@ -1,0 +1,36 @@
+varnishtest "happy path HTTPS backend fetch"
+
+feature tls
+
+server s1 {
+    tls_handshake
+    rxreq
+    expect req.url == "/"
+    txresp
+} -start
+
+varnish v1 -vcl {
+    import reqwest from "${vmod}";
+
+    backend default none;
+
+    sub vcl_init {
+        new client = reqwest.client(
+            base_url = "https://${s1_addr}:${s1_port}",
+            accept_invalid_certs = true,
+            accept_invalid_hostnames = true
+        );
+    }
+
+    sub vcl_recv {
+        set req.backend_hint = client.backend();
+    }
+} -start
+
+client c1 {
+    txreq
+    rxresp
+    expect resp.status == 200
+} -run
+
+server s1 -wait


### PR DESCRIPTION
## Summary
- Drop Varnish 8 from CI/`justfile` (min supported version back to 9.0+)
- Bump to 0.1.0
- Add `CHANGELOG.md`, backfilled with every prior release reconstructed from git history
- Update README version table with 0.1.0
- Add `tests/test17.vtc`: happy-path HTTPS backend fetch (no probe), complementing `test16.vtc`'s probe/invalid-cert coverage

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo clippy --all-features --all-targets` — clean
- [x] `cargo test --all-features` — all 17 `.vtc` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)