### PR TITLE
Add `copy_headers_to_resp()` to copy sideband response headers into `beresp`/`resp`

### DIFF
--- a/API.md
+++ b/API.md
@@ -107,6 +107,15 @@ Copy the native request headers (i.e. `req` or `bereq`) into the request named `
 * `STRING name`:
 request handle
 
+### Method `VOID <object>.copy_headers_to_resp(STRING name, STRING key)`
+
+Append every value of the response header `key` from the sideband request `name` onto the native response (`beresp` on the backend side, `resp` on the client side), one header line per value, so multi-value headers such as `Set-Cookie` are carried over without being joined (RFC 9110 §5.3, RFC 6265 §3). Lines are appended, never replaced. The request must have been created in the same task; if it failed, or the header is absent, nothing is copied. Only allowed where the response has a workspace: `vcl_backend_response`, `vcl_backend_refresh`, `vcl_backend_error`, `vcl_deliver` and `vcl_synth`.
+
+* `STRING name`:
+request handle
+* `STRING key`:
+name of the response header to copy
+
 ### Method `INT <object>.status(STRING name)`
 
 Retrieve the response status (send and wait if necessary), returns 0 if the response failed, but will cause a VCL error if call on a non-existing request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,11 +303,10 @@ mod reqwest {
                 return Ok(());
             };
 
-            let vcl_resp = ctx
-                .http_beresp
-                .as_mut()
-                .or(ctx.http_resp.as_mut())
-                .ok_or("reqwest.copy_headers_to_resp(): called outside of a response context")?;
+            let vcl_resp =
+                ctx.http_beresp.as_mut().or(ctx.http_resp.as_mut()).ok_or(
+                    "reqwest.copy_headers_to_resp(): called outside of a response context",
+                )?;
 
             for v in resp.headers.get_all(key) {
                 let v = v.to_str().map_err(|_| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ mod reqwest {
                 .http_beresp
                 .as_mut()
                 .or(ctx.http_resp.as_mut())
-                .ok_or("copy_headers_to_resp() called outside of a response context")?;
+                .ok_or("reqwest.copy_headers_to_resp(): called outside of a response context")?;
 
             for v in resp.headers.get_all(key) {
                 let v = v.to_str().map_err(|_| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,44 @@ mod reqwest {
             Ok(())
         }
 
+        /// Append every value of the response header `key` from the sideband request `name` onto the native response (`beresp` on the backend side, `resp` on the client side), one header line per value, so multi-value headers such as `Set-Cookie` are carried over without being joined (RFC 9110 §5.3, RFC 6265 §3). Lines are appended, never replaced. The request must have been created in the same task; if it failed, or the header is absent, nothing is copied. Only allowed where the response has a workspace: `vcl_backend_response`, `vcl_backend_refresh`, `vcl_backend_error`, `vcl_deliver` and `vcl_synth`.
+        #[restrict(
+            vcl_backend_response,
+            vcl_backend_refresh,
+            vcl_backend_error,
+            vcl_deliver,
+            vcl_synth
+        )]
+        pub fn copy_headers_to_resp(
+            &self,
+            ctx: &mut Ctx,
+            #[shared_per_vcl] vp_vcl: Option<&BgThread>,
+            #[shared_per_task] vp_task: &mut Option<Box<Vec<Entry>>>,
+            /// request handle
+            name: &str,
+            /// name of the response header to copy
+            key: &str,
+        ) -> Result<(), Box<dyn Error>> {
+            let Ok(resp) = self.get_resp(vp_vcl, vp_task, name)? else {
+                return Ok(());
+            };
+
+            let vcl_resp = ctx
+                .http_beresp
+                .as_mut()
+                .or(ctx.http_resp.as_mut())
+                .ok_or("copy_headers_to_resp() called outside of a response context")?;
+
+            for v in resp.headers.get_all(key) {
+                let v = v.to_str().map_err(|_| {
+                    format!("reqwest.copy_headers_to_resp(): header {key} is not visible ASCII")
+                })?;
+                vcl_resp.set_header(key, v)?;
+            }
+
+            Ok(())
+        }
+
         /// Retrieve the response status (send and wait if necessary), returns 0 if the response failed, but will cause a VCL error if call on a non-existing request.
         pub fn status(
             &self,

--- a/tests/test18.vtc
+++ b/tests/test18.vtc
@@ -1,0 +1,93 @@
+varnishtest ".copy_headers_to_resp()"
+
+# Sideband origin used from both the client and the backend side.
+server s1 {
+	rxreq
+	txresp -hdr "Set-Cookie: a=1" \
+	       -hdr "Set-Cookie: b=2; Expires=Wed, 21 Oct 2015 07:28:00 GMT" \
+	       -hdr "X-Multi: val1" -hdr "X-Multi: val2"
+} -repeat 2 -start
+
+# Real backend for the beresp case.
+server s2 {
+	rxreq
+	txresp -hdr "X-Origin: yes"
+} -start
+
+varnish v1 -vcl+backend {
+	import reqwest from "${vmod}";
+
+	sub vcl_init {
+		new client = reqwest.client();
+	}
+
+	sub vcl_recv {
+		if (req.url == "/synth") {
+			client.init("s1", "http://${s1_addr}:${s1_port}/");
+			client.send("s1");
+			return (synth(200));
+		}
+	}
+
+	sub vcl_synth {
+		client.copy_headers_to_resp("s1", "Set-Cookie");
+		client.copy_headers_to_resp("s1", "X-Multi");
+		# absent in the sideband response: no-op
+		client.copy_headers_to_resp("s1", "X-Missing");
+		return (deliver);
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = s2;
+		client.init("s1", "http://${s1_addr}:${s1_port}/");
+		client.send("s1");
+	}
+
+	sub vcl_backend_response {
+		client.copy_headers_to_resp("s1", "Set-Cookie");
+		client.copy_headers_to_resp("s1", "X-Multi");
+	}
+} -start
+
+logexpect l1 -v v1 -g vxid {
+	expect * * RespHeader "^Set-Cookie: a=1$"
+	expect * * RespHeader "^Set-Cookie: b=2; Expires=Wed, 21 Oct 2015 07:28:00 GMT$"
+	expect * * RespHeader "^X-Multi: val1$"
+	expect * * RespHeader "^X-Multi: val2$"
+	expect * * BerespHeader "^Set-Cookie: a=1$"
+	expect * * BerespHeader "^Set-Cookie: b=2; Expires=Wed, 21 Oct 2015 07:28:00 GMT$"
+	expect * * BerespHeader "^X-Multi: val1$"
+	expect * * BerespHeader "^X-Multi: val2$"
+} -start
+
+client c1 {
+	txreq -url "/synth"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.X-Missing == <undef>
+
+	txreq -url "/fetch"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.X-Origin == "yes"
+} -run
+
+logexpect l1 -wait
+
+server s1 -wait
+server s2 -wait
+
+# No response exists in vcl_recv (req->resp has no workspace yet), so the
+# method is restricted and VCC must reject it at compile time.
+varnish v1 -errvcl {Not available in subroutine 'vcl_recv'.} {
+	import reqwest from "${vmod}";
+	backend default none;
+
+	sub vcl_init {
+		new client = reqwest.client();
+	}
+
+	sub vcl_recv {
+		client.copy_headers_to_resp("s1", "Set-Cookie");
+	}
+}


### PR DESCRIPTION
`client.copy_headers_to_resp(name, key)` appends every value of header `key` from the sideband response `name` onto `beresp` (backend side) or `resp` (client side), one header line per value. Counterpart to `copy_headers_to_req()`.

**Why:** `header()` returns a single STRING: first match, or all matches joined with `sep`. That can't carry `Set-Cookie`: RFC 9110 §5.3 notes it doesn't use list syntax and cannot be combined into one field value, and RFC 6265 §3 says origin servers SHOULD NOT fold it (its `Expires` attribute contains a comma). This is #15.

**Design:**
- `#[restrict(vcl_backend_response, vcl_backend_refresh, vcl_backend_error, vcl_deliver, vcl_synth)]`. `ctx->http_resp` is `req->resp` in every client sub (`VCL_Req2Ctx`), but `req->resp` only gets a workspace in `Resp_Setup_Deliver()`/`Resp_Setup_Synth()`; `bo->beresp` likewise only after `vcl_backend_fetch` (`vbf_stp_startfetch`) and in `vbf_stp_error`. Anywhere else `set_header()` would write through a NULL `ws`. VCC rejects the call at compile time; the macro also emits a runtime guard.
- One `HttpHeaders::set_header()` call per value, same as the backend fetch path in `VCLBackend::get_response`, so multi-value headers are appended as-is. Non-visible-ASCII values fail the call, as there.
- `key` is required: copying a whole foreign response onto `beresp` would also duplicate `Content-Length` and friends next to the real ones. That's the "more dubious" half of #2 and is left out here.
- Copying `Set-Cookie` into `beresp` makes the builtin `vcl_beresp_cookie` mark the object hit-for-miss; copying into `resp` from `vcl_deliver`/`vcl_synth` doesn't touch cacheability.

**Test:** `test18.vtc`: two `Set-Cookie` lines (one with a comma-bearing `Expires`) and a repeated `X-Multi` survive into `resp` (`vcl_synth`) and `beresp` (`vcl_backend_response`), asserted with `logexpect` on `RespHeader`/`BerespHeader`; absent header is a no-op; `-errvcl` checks VCC rejects a call from `vcl_recv`.

Closes #15. Related: #2.
